### PR TITLE
Updated `load_oeps` to accept multiple states

### DIFF
--- a/R/attribute_formatting.R
+++ b/R/attribute_formatting.R
@@ -65,6 +65,11 @@ filter_by_geography <- function(df, states, counties) {
   }
   
   # states and counties both specified
+  if (length(states) > 1) {
+    stop('Cannot specify multiple states and counties at once. Instead,
+         pass five digit GEOIDs to counties parameter.')
+  }
+  
   state_fips <- state_to_fips(states)
   county_geoids <- county_to_fips(counties, state_fips)
   

--- a/R/attribute_formatting.R
+++ b/R/attribute_formatting.R
@@ -50,7 +50,9 @@ filter_by_geography <- function(df, states, counties) {
   }
   
   if (is.null(counties) & !is.null(states)) {
-    states <- state_to_fips(states)
+    
+    states <- sapply(states, state_to_fips,
+                     simplify=FALSE, USE.NAMES=TRUE)
     df <- filter_by_state(df, states)
     return(df)
   }
@@ -140,8 +142,6 @@ county_to_fips <- function(county, state_fips) {
 #' 
 #' @returns Dataframe containing only observations which occurred in a given state.
 filter_by_state <- function(df, states) {
-  
-  # TODO: add a reference to a look-up table to parse abbreviations, state names
   
   stopifnot("HEROP_ID" %in% names(df))
   

--- a/R/attribute_formatting.R
+++ b/R/attribute_formatting.R
@@ -50,7 +50,6 @@ filter_by_geography <- function(df, states, counties) {
   }
   
   if (is.null(counties) & !is.null(states)) {
-    
     states <- sapply(states, state_to_fips,
                      simplify=FALSE, USE.NAMES=TRUE)
     df <- filter_by_state(df, states)

--- a/R/load_oeps.R
+++ b/R/load_oeps.R
@@ -73,10 +73,15 @@ load_oeps <- function(scale, year, themes = "All", states=NULL, counties=NULL,
   
   if (tidy) attribute_data <- tidify_data(attribute_data)
 
-  if (!geometry) return(attribute_data)
+  if (!geometry) {
+    rownames(attribute_data) <- 1:nrow(attribute_data)
+    return(attribute_data)
+  }
   
   geometry <- retrieve_geometry(scale, quiet = TRUE)
   data <- merge(attribute_data, geometry, on = "HEROP_ID", how = "left")
+  
+  rownames(data) <- 1:nrow(data)
   return(sf::st_sf(data))
 }
 

--- a/R/load_oeps_dictionary.R
+++ b/R/load_oeps_dictionary.R
@@ -38,6 +38,7 @@ load_oeps_dictionary <- function(scale) {
       data_dictionary[data_dictionary$scale == 'zcta',] |>
       subset(select = -c(scale))
   }
-
+  
+  rownames(return_data) <- 1:nrow(return_data)
   return(return_data)
 }


### PR DESCRIPTION
It looks like the issue was caused by the usage of `state_to_fips` in `filter_by_geometry`; for some reason, `filter_by_geometry` (but not `filter_by_state`) assumed a singular state as input.

This _also_ gave a good chance to fix the error handling for cases where users attempt an ambiguous queries, such as the following:

```R
load_oeps('tract', states=c('Illinois', 'Minnesota', 'Georgia'), counties='Cook', year=2018)
```

We now provide a useful error message, which should be unable to flag non-ambiguous queries (which was what happened for issue #10). 

Lastly, it also also gave a good moment to actually reset indices for returned dataframes. Which has been done.